### PR TITLE
Make the middleware thread-safe

### DIFF
--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -38,6 +38,10 @@ module Rack
     end
 
     def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
       @status, @headers, @body = @app.call(env)
       return [@status, @headers, @body] unless html?
       response = Rack::Response.new([], @status, @headers)


### PR DESCRIPTION
In order to add thread safety, we duplicate the middleware call on runtime. A similar thing is done in e.g. Sinatra, nice comment about it [is here too](https://github.com/cerner/gc_stats/issues/3#issuecomment-83653869) and [this SO question](https://stackoverflow.com/questions/23028226/rack-middleware-and-thread-safety).

This should fix swapped requests issue for good, after applying this fix I was not able to reproduce this anymore and without it it is reproducible on local when using prod Docker image.